### PR TITLE
Fix Sequel add-on does not update README

### DIFF
--- a/lib/hoboken/add_ons/sequel.rb
+++ b/lib/hoboken/add_ons/sequel.rb
@@ -104,6 +104,36 @@ module Hoboken
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
+      def update_readme
+        snippet = <<~CODE
+          <tr>
+              <td>DATABASE_URL</td>
+              <td>Yes</td>
+              <td>
+                `sqlite://db/test.db` (for the test environment <em>only</em>)
+              </td>
+              <td>
+                Connection URL to the database. The format varies according
+                database adapter. Refer to the
+                <a href="https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html">
+                Sequel gem documentation</a> for more information. Some examples:
+                <dl>
+                  <dt>Sqlite3</dt>
+                  <dd>`sqlite://db/development.db`</dd>
+                  <dt>PostgreSQL</dt>
+                  <dd>`postgresql://localhost/myapp_development?pool=5`</dd>
+                </dl>
+              </td>
+          </tr>
+        CODE
+
+        insert_into_file('README.md', after: /<tbody>\n/) do
+          indent(snippet, 8)
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
       def reminders
         say "\nGemfile updated... don't forget to 'bundle install'"
         say <<~TEXT


### PR DESCRIPTION
**Description**
Update the Sequel add-on so that it updates the README with information about how to use the DATABASE_URL environment variable.

**Related Issue**
Closes #83

**Type of Change**
<!--- Place an `x` in each box that applies: --->
[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Code change (non-breaking change which changes existing non-public API)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
<!--- Place an `x` in each box if you have performed the indicated task. --->
[x] I have followed the guidelines in the `CONTRIBUTING.md` document.
[x] I have ensured that my code follows the code style of this project.
[x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update / change.
[x] I have checked that the CI build passes all tests and linters.
[ ] I have added tests to cover my changes.
[x] I have made any necessary changes to the documentation.
[ ] I have updated the `Unreleased` section of the `CHANGELOG.md` with a brief description of my change along with my GitHub username.
